### PR TITLE
Refactor/receive ephemeral key from frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration with @vecrea/oid4vc-core and @vecrea/oid4vc-prex
 - Build configuration with Vite and vite-plugin-dts
 - Comprehensive test suite with Vitest
+
+## [1.1.1] - 2025-07-xx
+
+### Changed
+
+- Receive ECDH-ES public key for wallet response encryption from Frontend instead of generating it at Endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Build configuration with Vite and vite-plugin-dts
 - Comprehensive test suite with Vitest
 
-## [1.1.1] - 2025-07-xx
+## [x.x.x] - 2025-07-xx
 
 ### Changed
 

--- a/docs/api/frontend/InitiateTransaction.md
+++ b/docs/api/frontend/InitiateTransaction.md
@@ -104,7 +104,6 @@ curl --location 'https://oid4vc-verifier-endpoint-hono.g-trustedweb.workers.dev/
       'x': 'ODhL-OY1pZC9m4n4sR8AcBkR6WR9Flf-auV62TfjCpw',
       'y': 'WViWpkI_U7eGs73bcEnb52LHCwJ9bUu121-ZOBfb6II',
       'crv': 'P-256',
-      'd': 'dA5oiahJprWwVfkZ2mSeNszBNLRHTS209SDvfoTneYM',
       'kid': '48ca2b34-4133-46c9-997a-91a28383e435',
       'use': 'enc',
       'alg': 'ECDH-ES'

--- a/docs/api/frontend/InitiateTransaction.md
+++ b/docs/api/frontend/InitiateTransaction.md
@@ -48,6 +48,7 @@ VP 提示フローの開始をリクエストをするためのエンドポイ�
 | jar_mode                                                                      | -                  | No   | 認可リクエストが Wallet に渡される方法を制御する。`by_value`または`by_reference`を指定する。`by_value`の場合は、認可リクエストが Wallet にインラインで渡され、`by_reference`の場合は、`request_uri`を経由して渡される。                           |
 | presentation_definition_mode                                                  | -                  | No   | Presentation Definition が Wallet に渡される方法を制御する。`by_value`または`by_reference`を指定する。`by_value`の場合は、認可リクエストが Wallet にインラインで渡され、`by_reference`の場合は、`presentation_definition_uri`を経由して渡される。 |
 | wallet_response_redirect_uri_template                                         | -                  | No   | Same device で VP 提示フローを実施した際に、Wallet から Verifier に VP を提示後 Wallet から Verifier Frontend へリダイレクトする際の URI のテンプレートを指定する。                                                                               |
+| ephemeral_ecdh_public_jwk                                                     | -                  | Yes  | Walletでvp_tokenを暗号化する際に使用するECDH-ESの公開鍵                                                                                                                                                                                           |
 
 ## レスポンス
 
@@ -85,11 +86,11 @@ curl --location 'https://oid4vc-verifier-endpoint-hono.g-trustedweb.workers.dev/
           "constraints": {
             "fields": [
               {
-                "path": ["$['\''org.iso.18013.5.1'\'']['\''given_name'\'']"],
+                "path": ["$['org.iso.18013.5.1']['given_name']"],
                 "intent_to_retain": false
               },
               {
-                "path": ["$['\''org.iso.18013.5.1'\'']['\''document_number'\'']"],
+                "path": ["$['org.iso.18013.5.1']['document_number']"],
                 "intent_to_retain": false
               }
             ]
@@ -97,7 +98,17 @@ curl --location 'https://oid4vc-verifier-endpoint-hono.g-trustedweb.workers.dev/
         }
       ]
     },
-    "nonce": "3b75b9b1-2463-4d4a-b921-adc21642c43c"
+    "nonce": "3b75b9b1-2463-4d4a-b921-adc21642c43c",
+    "ephemeral_ecdh_public_jwk" :"{
+      'kty': 'EC',
+      'x': 'ODhL-OY1pZC9m4n4sR8AcBkR6WR9Flf-auV62TfjCpw',
+      'y': 'WViWpkI_U7eGs73bcEnb52LHCwJ9bUu121-ZOBfb6II',
+      'crv': 'P-256',
+      'd': 'dA5oiahJprWwVfkZ2mSeNszBNLRHTS209SDvfoTneYM',
+      'kid': '48ca2b34-4133-46c9-997a-91a28383e435',
+      'use': 'enc',
+      'alg': 'ECDH-ES'
+    }"
   }'
 ```
 

--- a/lib/adapters/out/jose/SignRequestObjectJose.ts
+++ b/lib/adapters/out/jose/SignRequestObjectJose.ts
@@ -49,7 +49,7 @@ const invoke: SignRequestObject = async (
     presentation.requestId,
     verifierConfig.clientMetaData,
     requestObject.responseMode,
-    presentation.ephemeralECDHPrivateJwk
+    presentation.ephemeralECDHPublicJwk
   );
 
   return sign(

--- a/lib/domain/AuthorizationResponse.ts
+++ b/lib/domain/AuthorizationResponse.ts
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 
-import { PresentationSubmission } from '@vecrea/oid4vc-prex';
+import {
+  PresentationSubmission,
+  presentationSubmissionSchema,
+} from '@vecrea/oid4vc-prex';
 import { Jwt } from './types';
+import { z } from 'zod';
 
 /**
  * Represents the data structure for an authorization response.
@@ -34,6 +38,72 @@ export interface AuthorizationResponseData {
   /** Detailed description of the error, if an error occurred. */
   errorDescription?: string;
 }
+
+/**
+ * Schema for the DirectPost data.
+ * @typedef {Object} DirectPostSchema
+ * @property {Object} response - The response object.
+ *
+ * TODO - confirm this schema is correct
+ */
+export const directPostSchema = z.object({
+  response: z.object({
+    state: z.string(),
+    id_token: z.string().optional(),
+    vp_token: z.string().optional(),
+    presentation_submission: presentationSubmissionSchema,
+    error: z.string().optional(),
+    error_description: z.string().optional(),
+  }),
+});
+
+/**
+ * Schema for the DirectPostJwt data.
+ * @typedef {Object} DirectPostJwtSchema
+ * @property {string} state - The state parameter.
+ * @property {string} response - The response parameter.
+ */
+export const directPostJwtSchema = z.object({
+  state: z.string(),
+  response: z.string(),
+});
+
+/**
+ * Schema for the AuthorizationResponse data.
+ * @typedef {Object} AuthorizationResponseSchema
+ * @property {string} state - The state parameter.
+ * @property {string} response - The response parameter.
+ *
+ */
+export const authorizationResponseSchema = directPostJwtSchema;
+// z.union([
+//   directPostSchema,
+//   directPostJwtSchema,
+// ]);
+
+/**
+ * JSON representation of the DirectPost data.
+ * @typedef {Object} DirectPostJSON
+ * @property {Object} response - The response object.
+ */
+export type DirectPostJSON = z.infer<typeof directPostSchema>;
+
+/**
+ * JSON representation of the DirectPostJwt data.
+ * @typedef {Object} DirectPostJwtJSON
+ * @property {string} state - The state parameter.
+ * @property {string} response - The response parameter.
+ */
+export type DirectPostJwtJSON = z.infer<typeof directPostJwtSchema>;
+
+/**
+ * JSON representation of the AuthorizationResponse data.
+ * @typedef {Object} AuthorizationResponseJSON
+ * @property {Object} response - The response object.
+ */
+export type AuthorizationResponseJSON = z.infer<
+  typeof authorizationResponseSchema
+>;
 
 /**
  * Represents either a DirectPost or DirectPostJwt authorization response.
@@ -83,5 +153,16 @@ export namespace AuthorizationResponse {
      * @param jarm - The JWT Authorization Response Mode (JARM) token.
      */
     constructor(public readonly state: string, public readonly jarm: Jwt) {}
+
+    toJSON(): DirectPostJwtJSON {
+      return {
+        state: this.state,
+        response: this.jarm,
+      };
+    }
+
+    static fromJSON(json: DirectPostJwtJSON): DirectPostJwt {
+      return new DirectPostJwt(json.state, json.response);
+    }
   }
 }

--- a/lib/domain/EphemeralECDHPublicJwk.ts
+++ b/lib/domain/EphemeralECDHPublicJwk.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { z } from 'zod';
+
+/**
+ * Zod schema for validating the structure of a JWK (JSON Web Key) object.
+ *
+ * This schema ensures that the JWK object contains the following required properties:
+ * - kty: Key Type (string)
+ * - crv: Curve (string)
+ * - x: X Coordinate (string)
+ * - y: Y Coordinate (string)
+ *
+ * @type {z.ZodObject<{kty: z.ZodString, crv: z.ZodString, x: z.ZodString, y: z.ZodString}>}
+ */
+const jwkSchema = z.object({
+  kty: z.string(),
+  crv: z.string(),
+  x: z.string(),
+  y: z.string(),
+});
+
+/**
+ * Zod schema for validating an ephemeral ECDH public key in JWK format as a JSON string.
+ *
+ * This schema applies the following validations:
+ * 1. The input must be a string.
+ * 2. The string must be a valid JSON.
+ * 3. The parsed JSON object must conform to the jwkSchema structure.
+ *
+ * @type {z.ZodEffects<z.ZodString>}
+ *
+ * @example
+ * // Valid usage
+ * const validJwk = '{"kty":"EC","crv":"P-256","x":"example-x","y":"example-y"}';
+ * ephemeralECDHPublicJwkSchema.parse(validJwk); // Returns the validJwk string
+ *
+ * // Invalid usage (will throw ZodError)
+ * ephemeralECDHPublicJwkSchema.parse('{"kty":"EC"}'); // Missing required properties
+ * ephemeralECDHPublicJwkSchema.parse('not a json'); // Not a valid JSON string
+ *
+ * @throws {z.ZodError} Throws a ZodError if the input fails validation
+ */
+export const ephemeralECDHPublicJwkSchema = z.string().refine(
+  (str) => {
+    try {
+      const parsed = JSON.parse(str);
+      return jwkSchema.safeParse(parsed).success;
+    } catch {
+      return false;
+    }
+  },
+  {
+    message:
+      'Must be a valid JSON string representing a JWK with kty, crv, x, and y properties',
+  }
+);
+
+/**
+ * Represents an ephemeral ECDH public key in JWK format.
+ *
+ * This class encapsulates a JWK string representing an ephemeral ECDH public key.
+ * It provides methods for JSON serialization.
+ */
+export class EphemeralECDHPublicJwk {
+  /**
+   * Creates a new instance of EphemeralECDHPublicJwk.
+   *
+   * @param {string} value - The JWK string representing the ephemeral ECDH public key.
+   */
+  constructor(public value: string) {}
+
+  /**
+   * Returns the JWK string for JSON serialization.
+   *
+   * This method is used by JSON.stringify() to serialize the object.
+   *
+   * @returns {string} The JWK string.
+   */
+  toJSON(): string {
+    return this.value;
+  }
+}

--- a/lib/domain/EphemeralECDHPublicJwk.ts
+++ b/lib/domain/EphemeralECDHPublicJwk.ts
@@ -55,20 +55,23 @@ const jwkSchema = z.object({
  *
  * @throws {z.ZodError} Throws a ZodError if the input fails validation
  */
-export const ephemeralECDHPublicJwkSchema = z.string().refine(
-  (str) => {
-    try {
-      const parsed = JSON.parse(str);
-      return jwkSchema.safeParse(parsed).success;
-    } catch {
-      return false;
+export const ephemeralECDHPublicJwkSchema = z.union([
+  z.string().refine(
+    (str) => {
+      try {
+        const parsed = JSON.parse(str);
+        return jwkSchema.safeParse(parsed).success;
+      } catch {
+        return false;
+      }
+    },
+    {
+      message:
+        'Must be a valid JSON string representing a JWK with kty, crv, x, and y properties',
     }
-  },
-  {
-    message:
-      'Must be a valid JSON string representing a JWK with kty, crv, x, and y properties',
-  }
-);
+  ),
+  jwkSchema.transform((jwk) => JSON.stringify(jwk)),
+]);
 
 /**
  * Represents an ephemeral ECDH public key in JWK format.

--- a/lib/domain/Presentation.ts
+++ b/lib/domain/Presentation.ts
@@ -515,8 +515,7 @@ export namespace Presentation {
      */
     submit(
       at: Date,
-      // TODO: support DirectPost
-      walletResponse: AuthorizationResponse.DirectPostJwt,
+      walletResponse: AuthorizationResponse,
       responseCode: ResponseCode | undefined
     ): Result<Presentation.Submitted> {
       return runCatching(
@@ -612,8 +611,7 @@ export namespace Presentation {
         new RequestId(json.request_id),
         new Date(json.request_object_retrieved_at),
         new Date(json.submitted_at),
-        // TODO: support DirectPost
-        AuthorizationResponse.DirectPostJwt.fromJSON(json.wallet_response),
+        AuthorizationResponse.fromJSON(json.wallet_response),
         new Nonce(json.nonce),
         json.response_code ? new ResponseCode(json.response_code) : undefined
       );
@@ -637,8 +635,7 @@ export namespace Presentation {
       public requestId: RequestId,
       public requestObjectRetrievedAt: Date,
       public submittedAt: Date,
-      // TODO: support DirectPost
-      public walletResponse: AuthorizationResponse.DirectPostJwt,
+      public walletResponse: AuthorizationResponse,
       public nonce: Nonce,
       public responseCode: ResponseCode | undefined
     ) {

--- a/lib/domain/Presentation.ts
+++ b/lib/domain/Presentation.ts
@@ -18,10 +18,14 @@ import { z } from 'zod';
 import { TransactionId, transactionIdSchema } from './TransactionId';
 import { PresentationType, presentationTypeSchema } from './PresentationType';
 import { RequestId, requestIdScheme } from './RequestId';
+// import {
+//   EphemeralECDHPrivateJwk,
+//   ephemeralECDHPrivateJwkSchema,
+// } from './EphemeralECDHPrivateJwk';
 import {
-  EphemeralECDHPrivateJwk,
-  ephemeralECDHPrivateJwkSchema,
-} from './EphemeralECDHPrivateJwk';
+  EphemeralECDHPublicJwk,
+  ephemeralECDHPublicJwkSchema,
+} from './EphemeralECDHPublicJwk';
 import {
   ResponseModeOption,
   responseModeOptionSchema,
@@ -32,11 +36,15 @@ import {
   getWalletResponseMethodSchema,
 } from './GetWalletResponseMethod';
 import { Nonce, nonceSchema } from './Nonce';
-import { WalletResponse, walletResponseSchema } from './WalletResponse';
+// import { WalletResponse } from './WalletResponse';
 import { ResponseCode, responseCodeSchema } from './ResponseCode';
 import { iso8601Schema } from './iso8601Schema';
 import { FromJSON } from '../common/json/FromJSON';
 import { Result, runCatching } from '@vecrea/oid4vc-core/utils';
+import {
+  AuthorizationResponse,
+  authorizationResponseSchema,
+} from './AuthorizationResponse';
 
 /**
  * Represents a presentation.
@@ -68,7 +76,7 @@ const requestedSchema = z.object({
   type: presentationTypeSchema,
   request_id: requestIdScheme,
   nonce: nonceSchema,
-  ephemeral_ecdh_private_jwk: z.optional(ephemeralECDHPrivateJwkSchema),
+  ephemeral_ecdh_public_jwk: z.optional(ephemeralECDHPublicJwkSchema),
   response_mode: responseModeOptionSchema,
   presentation_definition_mode: embedOptionSchema,
   get_wallet_response_method: getWalletResponseMethodSchema,
@@ -96,7 +104,7 @@ const requestObjectRetrievedSchema = z.object({
   request_id: requestIdScheme,
   request_object_retrieved_at: iso8601Schema,
   nonce: nonceSchema,
-  ephemeral_ecdh_private_jwk: z.optional(ephemeralECDHPrivateJwkSchema),
+  ephemeral_ecdh_public_jwk: z.optional(ephemeralECDHPublicJwkSchema),
   response_mode: responseModeOptionSchema,
   get_wallet_response_method: getWalletResponseMethodSchema,
 });
@@ -123,7 +131,7 @@ const submittedSchema = z.object({
   request_id: requestIdScheme,
   request_object_retrieved_at: iso8601Schema,
   submitted_at: iso8601Schema,
-  wallet_response: walletResponseSchema,
+  wallet_response: authorizationResponseSchema,
   nonce: nonceSchema,
   response_code: z.optional(responseCodeSchema),
 });
@@ -328,8 +336,8 @@ export namespace Presentation {
         PresentationType.fromJSON(json.type),
         new RequestId(json.request_id),
         new Nonce(json.nonce),
-        json.ephemeral_ecdh_private_jwk
-          ? new EphemeralECDHPrivateJwk(json.ephemeral_ecdh_private_jwk)
+        json.ephemeral_ecdh_public_jwk
+          ? new EphemeralECDHPublicJwk(json.ephemeral_ecdh_public_jwk)
           : undefined,
         json.response_mode,
         EmbedOption.fromJSON(json.presentation_definition_mode),
@@ -353,7 +361,7 @@ export namespace Presentation {
       public type: PresentationType,
       public requestId: RequestId,
       public nonce: Nonce,
-      public ephemeralECDHPrivateJwk: EphemeralECDHPrivateJwk | undefined,
+      public ephemeralECDHPublicJwk: EphemeralECDHPublicJwk | undefined,
       public responseMode: ResponseModeOption,
       public presentationDefinitionMode: EmbedOption,
       public getWalletResponseMethod: GetWalletResponseMethod
@@ -374,7 +382,7 @@ export namespace Presentation {
             this.requestId,
             at,
             this.nonce,
-            this.ephemeralECDHPrivateJwk,
+            this.ephemeralECDHPublicJwk,
             this.responseMode,
             this.getWalletResponseMethod
           )
@@ -409,8 +417,8 @@ export namespace Presentation {
         get_wallet_response_method: this.getWalletResponseMethod.toJSON(),
       };
 
-      if (this.ephemeralECDHPrivateJwk) {
-        json.ephemeral_ecdh_private_jwk = this.ephemeralECDHPrivateJwk.toJSON();
+      if (this.ephemeralECDHPublicJwk) {
+        json.ephemeral_ecdh_public_jwk = this.ephemeralECDHPublicJwk.toJSON();
       }
 
       return json;
@@ -458,8 +466,8 @@ export namespace Presentation {
         new RequestId(json.request_id),
         new Date(json.request_object_retrieved_at),
         new Nonce(json.nonce),
-        json.ephemeral_ecdh_private_jwk
-          ? new EphemeralECDHPrivateJwk(json.ephemeral_ecdh_private_jwk)
+        json.ephemeral_ecdh_public_jwk
+          ? new EphemeralECDHPublicJwk(json.ephemeral_ecdh_public_jwk)
           : undefined,
         json.response_mode,
         GetWalletResponseMethod.fromJSON(json.get_wallet_response_method)
@@ -484,7 +492,7 @@ export namespace Presentation {
       public requestId: RequestId,
       public requestObjectRetrievedAt: Date,
       public nonce: Nonce,
-      public ephemeralECDHPrivateJwk: EphemeralECDHPrivateJwk | undefined,
+      public ephemeralECDHPublicJwk: EphemeralECDHPublicJwk | undefined,
       public responseMode: ResponseModeOption,
       public getWalletResponseMethod: GetWalletResponseMethod
     ) {
@@ -507,7 +515,8 @@ export namespace Presentation {
      */
     submit(
       at: Date,
-      walletResponse: WalletResponse,
+      // TODO: support DirectPost
+      walletResponse: AuthorizationResponse.DirectPostJwt,
       responseCode: ResponseCode | undefined
     ): Result<Presentation.Submitted> {
       return runCatching(
@@ -555,8 +564,8 @@ export namespace Presentation {
         get_wallet_response_method: this.getWalletResponseMethod.toJSON(),
       };
 
-      if (this.ephemeralECDHPrivateJwk) {
-        json.ephemeral_ecdh_private_jwk = this.ephemeralECDHPrivateJwk.toJSON();
+      if (this.ephemeralECDHPublicJwk) {
+        json.ephemeral_ecdh_public_jwk = this.ephemeralECDHPublicJwk.toJSON();
       }
 
       return json;
@@ -603,7 +612,8 @@ export namespace Presentation {
         new RequestId(json.request_id),
         new Date(json.request_object_retrieved_at),
         new Date(json.submitted_at),
-        WalletResponse.fromJson(json.wallet_response),
+        // TODO: support DirectPost
+        AuthorizationResponse.DirectPostJwt.fromJSON(json.wallet_response),
         new Nonce(json.nonce),
         json.response_code ? new ResponseCode(json.response_code) : undefined
       );
@@ -616,7 +626,7 @@ export namespace Presentation {
      * @param {RequestId} requestId - The request ID.
      * @param {Date} requestObjectRetrievedAt - The request object retrieval date and time.
      * @param {Date} submittedAt - The submission date and time.
-     * @param {WalletResponse} walletResponse - The wallet response.
+     * @param {AuthorizationResponse} walletResponse - The wallet response.
      * @param {Nonce} nonce - The nonce.
      * @param {ResponseCode | undefined} responseCode - The response code.
      */
@@ -627,7 +637,8 @@ export namespace Presentation {
       public requestId: RequestId,
       public requestObjectRetrievedAt: Date,
       public submittedAt: Date,
-      public walletResponse: WalletResponse,
+      // TODO: support DirectPost
+      public walletResponse: AuthorizationResponse.DirectPostJwt,
       public nonce: Nonce,
       public responseCode: ResponseCode | undefined
     ) {

--- a/lib/domain/__tests__/Presentation.RequestObjectRetrieved.spec.ts
+++ b/lib/domain/__tests__/Presentation.RequestObjectRetrieved.spec.ts
@@ -4,13 +4,15 @@ import {
   RequestId,
   Nonce,
   IdTokenType,
-  EphemeralECDHPrivateJwk,
+  // EphemeralECDHPrivateJwk,
   GetWalletResponseMethod,
   ResponseModeOption,
   Presentation,
   PresentationType,
   ResponseCode,
-  WalletResponse,
+  // WalletResponse,
+  EphemeralECDHPublicJwk,
+  AuthorizationResponse,
 } from '..';
 import { Id, PresentationDefinition } from '@vecrea/oid4vc-prex';
 
@@ -21,7 +23,7 @@ describe('RequestObjectRetrieved', () => {
   const requestId = new RequestId('request-id');
   const requestObjectRetrievedAt = new Date('2023-06-08T10:30:00Z');
   const nonce = new Nonce('nonce');
-  const ephemeralECDHPrivateJwk = new EphemeralECDHPrivateJwk('hoge');
+  const ephemeralECDHPublicJwk = new EphemeralECDHPublicJwk('hoge');
   const responseMode = ResponseModeOption.DirectPostJwt;
   const getWalletResponseMethod = new GetWalletResponseMethod.Redirect(
     'http://example.com/{requestId}'
@@ -35,7 +37,7 @@ describe('RequestObjectRetrieved', () => {
       requestId,
       requestObjectRetrievedAt,
       nonce,
-      ephemeralECDHPrivateJwk,
+      ephemeralECDHPublicJwk,
       responseMode,
       getWalletResponseMethod
     );
@@ -48,8 +50,8 @@ describe('RequestObjectRetrieved', () => {
       requestObjectRetrievedAt
     );
     expect(requestObjectRetrieved.nonce).toBe(nonce);
-    expect(requestObjectRetrieved.ephemeralECDHPrivateJwk).toBe(
-      ephemeralECDHPrivateJwk
+    expect(requestObjectRetrieved.ephemeralECDHPublicJwk).toBe(
+      ephemeralECDHPublicJwk
     );
     expect(requestObjectRetrieved.responseMode).toBe(responseMode);
     expect(requestObjectRetrieved.getWalletResponseMethod).toBe(
@@ -67,7 +69,7 @@ describe('RequestObjectRetrieved', () => {
         requestId,
         requestObjectRetrievedAt,
         nonce,
-        ephemeralECDHPrivateJwk,
+        ephemeralECDHPublicJwk,
         responseMode,
         getWalletResponseMethod
       );
@@ -84,13 +86,16 @@ describe('RequestObjectRetrieved', () => {
       requestId,
       requestObjectRetrievedAt,
       nonce,
-      ephemeralECDHPrivateJwk,
+      ephemeralECDHPublicJwk,
       responseMode,
       getWalletResponseMethod
     );
 
     const submittedAt = new Date('2023-06-08T11:00:00Z');
-    const walletResponse = new WalletResponse.IdToken('token');
+    const walletResponse = new AuthorizationResponse.DirectPostJwt(
+      'state',
+      'response'
+    );
     const responseCode = new ResponseCode('success');
 
     const result = requestObjectRetrieved.submit(
@@ -122,7 +127,7 @@ describe('RequestObjectRetrieved', () => {
         requestId,
         requestObjectRetrievedAt,
         nonce,
-        ephemeralECDHPrivateJwk,
+        ephemeralECDHPublicJwk,
         responseMode,
         getWalletResponseMethod
       );
@@ -136,8 +141,8 @@ describe('RequestObjectRetrieved', () => {
           requestObjectRetrievedAt
         );
         expect(presentation.nonce).toBe(nonce);
-        expect(presentation.ephemeralECDHPrivateJwk).toBe(
-          ephemeralECDHPrivateJwk
+        expect(presentation.ephemeralECDHPublicJwk).toBe(
+          ephemeralECDHPublicJwk
         );
         expect(presentation.responseMode).toBe(responseMode);
         expect(presentation.getWalletResponseMethod).toBe(
@@ -158,7 +163,7 @@ describe('RequestObjectRetrieved', () => {
         requestId,
         requestObjectRetrievedAt,
         nonce,
-        ephemeralECDHPrivateJwk,
+        ephemeralECDHPublicJwk,
         responseMode,
         getWalletResponseMethod
       );
@@ -173,8 +178,8 @@ describe('RequestObjectRetrieved', () => {
             requestObjectRetrievedAt
           );
           expect(presentation.nonce).toBe(nonce);
-          expect(presentation.ephemeralECDHPrivateJwk).toBe(
-            ephemeralECDHPrivateJwk
+          expect(presentation.ephemeralECDHPublicJwk).toBe(
+            ephemeralECDHPublicJwk
           );
           expect(presentation.responseMode).toBe(responseMode);
           expect(presentation.getWalletResponseMethod).toBe(
@@ -199,7 +204,7 @@ describe('RequestObjectRetrieved', () => {
       const requestId = new RequestId('def456');
       const requestObjectRetrievedAt = new Date(0);
       const nonce = new Nonce('ghi789');
-      const ephemeralECDHPrivateJwk = new EphemeralECDHPrivateJwk('hoge');
+      const ephemeralECDHPublicJwk = new EphemeralECDHPublicJwk('hoge');
       const responseMode = ResponseModeOption.DirectPost;
       const getWalletResponseMethod = GetWalletResponseMethod.Poll.INSTANCE;
 
@@ -210,7 +215,7 @@ describe('RequestObjectRetrieved', () => {
         requestId,
         requestObjectRetrievedAt,
         nonce,
-        ephemeralECDHPrivateJwk,
+        ephemeralECDHPublicJwk,
         responseMode,
         getWalletResponseMethod
       );
@@ -235,7 +240,7 @@ describe('RequestObjectRetrieved', () => {
         request_id: 'def456',
         request_object_retrieved_at: '1970-01-01T00:00:00.000Z',
         nonce: 'ghi789',
-        ephemeral_ecdh_private_jwk: 'hoge',
+        ephemeral_ecdh_public_jwk: 'hoge',
         response_mode: 'direct_post',
         get_wallet_response_method: {
           __type: 'Poll',
@@ -264,7 +269,7 @@ describe('RequestObjectRetrieved', () => {
         request_id: 'def456',
         request_object_retrieved_at: '1970-01-01T00:00:00.000Z',
         nonce: 'ghi789',
-        ephemeral_ecdh_private_jwk: 'hoge',
+        ephemeral_ecdh_public_jwk: 'hoge',
         response_mode: 'direct_post',
         get_wallet_response_method: {
           __type: 'Poll',
@@ -291,8 +296,8 @@ describe('RequestObjectRetrieved', () => {
         new Date('1970-01-01T00:00:00.000Z')
       );
       expect(requestObjectRetrieved.nonce).toEqual(new Nonce('ghi789'));
-      expect(requestObjectRetrieved.ephemeralECDHPrivateJwk).toEqual(
-        new EphemeralECDHPrivateJwk('hoge')
+      expect(requestObjectRetrieved.ephemeralECDHPublicJwk).toEqual(
+        new EphemeralECDHPublicJwk('hoge')
       );
       expect(requestObjectRetrieved.responseMode).toEqual(
         ResponseModeOption.DirectPost
@@ -328,7 +333,7 @@ describe('RequestObjectRetrieved', () => {
       expect(requestObjectRetrieved).toBeInstanceOf(
         Presentation.RequestObjectRetrieved
       );
-      expect(requestObjectRetrieved.ephemeralECDHPrivateJwk).toBeUndefined();
+      expect(requestObjectRetrieved.ephemeralECDHPublicJwk).toBeUndefined();
     });
   });
 });

--- a/lib/domain/__tests__/Presentation.Requested.spec.ts
+++ b/lib/domain/__tests__/Presentation.Requested.spec.ts
@@ -3,13 +3,14 @@ import {
   TransactionId,
   RequestId,
   Nonce,
-  EphemeralECDHPrivateJwk,
+  // EphemeralECDHPrivateJwk,
   IdTokenType,
   EmbedOption,
   GetWalletResponseMethod,
   ResponseModeOption,
   Presentation,
   PresentationType,
+  EphemeralECDHPublicJwk,
 } from '..';
 import { Id, PresentationDefinition } from '@vecrea/oid4vc-prex';
 
@@ -19,7 +20,7 @@ describe('Requested', () => {
   const type = new PresentationType.IdTokenRequest([IdTokenType.SubjectSigned]);
   const requestId = new RequestId('request-id');
   const nonce = new Nonce('nonce');
-  const ephemeralECDHPrivateJwk = new EphemeralECDHPrivateJwk('hoge');
+  const ephemeralECDHPublicJwk = new EphemeralECDHPublicJwk('hoge');
   const responseMode = ResponseModeOption.DirectPostJwt;
   const presentationDefinitionMode = EmbedOption.ByValue.INSTANCE;
   const getWalletResponseMethod = new GetWalletResponseMethod.Redirect(
@@ -33,7 +34,7 @@ describe('Requested', () => {
       type,
       requestId,
       nonce,
-      ephemeralECDHPrivateJwk,
+      ephemeralECDHPublicJwk,
       responseMode,
       presentationDefinitionMode,
       getWalletResponseMethod
@@ -44,7 +45,7 @@ describe('Requested', () => {
     expect(requested.type).toBe(type);
     expect(requested.requestId).toBe(requestId);
     expect(requested.nonce).toBe(nonce);
-    expect(requested.ephemeralECDHPrivateJwk).toBe(ephemeralECDHPrivateJwk);
+    expect(requested.ephemeralECDHPublicJwk).toBe(ephemeralECDHPublicJwk);
     expect(requested.responseMode).toBe(responseMode);
     expect(requested.presentationDefinitionMode).toBe(
       presentationDefinitionMode
@@ -59,7 +60,7 @@ describe('Requested', () => {
       type,
       requestId,
       nonce,
-      ephemeralECDHPrivateJwk,
+      ephemeralECDHPublicJwk,
       responseMode,
       presentationDefinitionMode,
       getWalletResponseMethod
@@ -93,7 +94,7 @@ describe('Requested', () => {
         type,
         requestId,
         nonce,
-        ephemeralECDHPrivateJwk,
+        ephemeralECDHPublicJwk,
         responseMode,
         presentationDefinitionMode,
         getWalletResponseMethod
@@ -105,8 +106,8 @@ describe('Requested', () => {
         expect(presentation.type).toBe(type);
         expect(presentation.requestId).toBe(requestId);
         expect(presentation.nonce).toBe(nonce);
-        expect(presentation.ephemeralECDHPrivateJwk).toBe(
-          ephemeralECDHPrivateJwk
+        expect(presentation.ephemeralECDHPublicJwk).toBe(
+          ephemeralECDHPublicJwk
         );
         expect(presentation.responseMode).toBe(responseMode);
         expect(presentation.presentationDefinitionMode).toBe(
@@ -127,7 +128,7 @@ describe('Requested', () => {
         type,
         requestId,
         nonce,
-        ephemeralECDHPrivateJwk,
+        ephemeralECDHPublicJwk,
         responseMode,
         presentationDefinitionMode,
         getWalletResponseMethod
@@ -140,8 +141,8 @@ describe('Requested', () => {
           expect(presentation.type).toBe(type);
           expect(presentation.requestId).toBe(requestId);
           expect(presentation.nonce).toBe(nonce);
-          expect(presentation.ephemeralECDHPrivateJwk).toBe(
-            ephemeralECDHPrivateJwk
+          expect(presentation.ephemeralECDHPublicJwk).toBe(
+            ephemeralECDHPublicJwk
           );
           expect(presentation.responseMode).toBe(responseMode);
           expect(presentation.presentationDefinitionMode).toBe(
@@ -174,7 +175,7 @@ describe('Requested', () => {
         type,
         requestId,
         nonce,
-        ephemeralECDHPrivateJwk,
+        ephemeralECDHPublicJwk,
         responseMode,
         presentationDefinitionMode,
         getWalletResponseMethod
@@ -199,7 +200,7 @@ describe('Requested', () => {
         },
         request_id: 'def456',
         nonce: 'ghi789',
-        ephemeral_ecdh_private_jwk: 'hoge',
+        ephemeral_ecdh_public_jwk: 'hoge',
         response_mode: 'direct_post',
         presentation_definition_mode: {
           __type: 'ByValue',
@@ -230,7 +231,7 @@ describe('Requested', () => {
         },
         request_id: 'def456',
         nonce: 'ghi789',
-        ephemeral_ecdh_private_jwk: 'hoge',
+        ephemeral_ecdh_public_jwk: 'hoge',
         response_mode: 'direct_post',
         presentation_definition_mode: {
           __type: 'ByValue',
@@ -254,8 +255,8 @@ describe('Requested', () => {
       );
       expect(requested.requestId).toEqual(new RequestId('def456'));
       expect(requested.nonce).toEqual(new Nonce('ghi789'));
-      expect(requested.ephemeralECDHPrivateJwk).toEqual(
-        new EphemeralECDHPrivateJwk('hoge')
+      expect(requested.ephemeralECDHPublicJwk).toEqual(
+        new EphemeralECDHPublicJwk('hoge')
       );
       expect(requested.responseMode).toEqual(ResponseModeOption.DirectPost);
       expect(requested.presentationDefinitionMode).toEqual(
@@ -296,7 +297,7 @@ describe('Requested', () => {
       const requested = Presentation.Requested.fromJSON(json);
 
       expect(requested).toBeInstanceOf(Presentation.Requested);
-      expect(requested.ephemeralECDHPrivateJwk).toBeUndefined();
+      expect(requested.ephemeralECDHPublicJwk).toBeUndefined();
     });
   });
 });

--- a/lib/domain/__tests__/Presentation.Submitted.spec.ts
+++ b/lib/domain/__tests__/Presentation.Submitted.spec.ts
@@ -236,7 +236,7 @@ describe('Submitted', () => {
       expect(submitted.walletResponse).toMatchObject({
         __type: expectedWalletResponse.__type,
         state: expectedWalletResponse.state,
-        response: expectedWalletResponse.jarm,
+        jarm: expectedWalletResponse.jarm,
       });
       expect(submitted.nonce).toEqual(new Nonce('ghi789'));
       expect(submitted.responseCode).toEqual(new ResponseCode('efg'));

--- a/lib/domain/__tests__/Presentation.Submitted.spec.ts
+++ b/lib/domain/__tests__/Presentation.Submitted.spec.ts
@@ -6,8 +6,9 @@ import {
   ResponseCode,
   PresentationType,
   Presentation,
-  WalletResponse,
+  // WalletResponse,
   IdTokenType,
+  AuthorizationResponse,
 } from '..';
 import { Id, PresentationDefinition } from '@vecrea/oid4vc-prex';
 
@@ -18,7 +19,10 @@ describe('Submitted', () => {
   const requestId = new RequestId('request-id');
   const requestObjectRetrievedAt = new Date('2023-06-01T10:01:00Z');
   const submittedAt = new Date('2023-06-01T10:02:00Z');
-  const walletResponse = new WalletResponse.IdToken('aa');
+  const walletResponse = new AuthorizationResponse.DirectPostJwt(
+    'state',
+    'response'
+  );
   const nonce = new Nonce('nonce');
   const responseCode = new ResponseCode('response_code');
 
@@ -174,8 +178,8 @@ describe('Submitted', () => {
         request_object_retrieved_at: '1970-01-01T00:00:00.000Z',
         submitted_at: '1970-01-01T00:00:00.000Z',
         wallet_response: {
-          __type: 'IdToken',
-          id_token: 'aa',
+          state: 'state',
+          response: 'response',
         },
         nonce: 'ghi789',
         response_code: 'efg',
@@ -199,8 +203,8 @@ describe('Submitted', () => {
         request_object_retrieved_at: '1970-01-01T00:00:00.000Z',
         submitted_at: '1970-01-01T00:00:00.000Z',
         wallet_response: {
-          __type: 'IdToken',
-          id_token: 'aa',
+          state: 'state',
+          response: 'response',
         },
         nonce: 'ghi789',
         response_code: 'efg',
@@ -225,10 +229,14 @@ describe('Submitted', () => {
       expect(submitted.submittedAt).toEqual(
         new Date('1970-01-01T00:00:00.000Z')
       );
-      const expectedWalletResponse = new WalletResponse.IdToken('aa');
+      const expectedWalletResponse = new AuthorizationResponse.DirectPostJwt(
+        'state',
+        'response'
+      );
       expect(submitted.walletResponse).toMatchObject({
         __type: expectedWalletResponse.__type,
-        idToken: expectedWalletResponse.idToken,
+        state: expectedWalletResponse.state,
+        response: expectedWalletResponse.jarm,
       });
       expect(submitted.nonce).toEqual(new Nonce('ghi789'));
       expect(submitted.responseCode).toEqual(new ResponseCode('efg'));
@@ -249,8 +257,8 @@ describe('Submitted', () => {
         request_object_retrieved_at: '1970-01-01T00:00:00.000Z',
         submitted_at: '1970-01-01T00:00:00.000Z',
         wallet_response: {
-          __type: 'IdToken',
-          id_token: 'aa',
+          state: 'state',
+          response: 'response',
         },
         nonce: 'ghi789',
       };

--- a/lib/domain/__tests__/Presentation.spec.ts
+++ b/lib/domain/__tests__/Presentation.spec.ts
@@ -142,7 +142,7 @@ describe('Presentation.fromJSON', () => {
     expect(presentation.submittedAt).toEqual(new Date('2023-06-08T10:10:00Z'));
     expect(presentation.walletResponse).toMatchObject({
       state: 'state',
-      response: 'response',
+      jarm: 'response',
     });
     expect(presentation.nonce).toEqual(new Nonce('nonce-value'));
     expect(presentation.responseCode).toEqual(

--- a/lib/domain/__tests__/Presentation.spec.ts
+++ b/lib/domain/__tests__/Presentation.spec.ts
@@ -6,11 +6,12 @@ import {
   RequestId,
   PresentationType,
   Nonce,
-  EphemeralECDHPrivateJwk,
+  // EphemeralECDHPrivateJwk,
   ResponseModeOption,
   EmbedOption,
   GetWalletResponseMethod,
   ResponseCode,
+  EphemeralECDHPublicJwk,
 } from '..';
 
 describe('Presentation.fromJSON', () => {
@@ -27,7 +28,7 @@ describe('Presentation.fromJSON', () => {
       },
       request_id: 'request-id',
       nonce: 'nonce-value',
-      ephemeral_ecdh_private_jwk: 'private-jwk',
+      ephemeral_ecdh_public_jwk: 'public-jwk',
       response_mode: 'direct_post',
       presentation_definition_mode: {
         __type: 'ByValue',
@@ -49,8 +50,8 @@ describe('Presentation.fromJSON', () => {
     expect(presentation.type).toBeInstanceOf(PresentationType.VpTokenRequest);
     expect(presentation.requestId).toEqual(new RequestId('request-id'));
     expect(presentation.nonce).toEqual(new Nonce('nonce-value'));
-    expect(presentation.ephemeralECDHPrivateJwk).toEqual(
-      new EphemeralECDHPrivateJwk('private-jwk')
+    expect(presentation.ephemeralECDHPublicJwk).toEqual(
+      new EphemeralECDHPublicJwk('public-jwk')
     );
     expect(presentation.responseMode).toEqual(ResponseModeOption.DirectPost);
     expect(presentation.presentationDefinitionMode).toEqual(
@@ -73,7 +74,7 @@ describe('Presentation.fromJSON', () => {
       request_id: 'request-id',
       request_object_retrieved_at: '2023-06-08T10:05:00Z',
       nonce: 'nonce-value',
-      ephemeral_ecdh_private_jwk: 'private-jwk',
+      ephemeral_ecdh_public_jwk: 'public-jwk',
       response_mode: 'direct_post',
       get_wallet_response_method: {
         __type: 'Poll',
@@ -95,8 +96,8 @@ describe('Presentation.fromJSON', () => {
       new Date('2023-06-08T10:05:00Z')
     );
     expect(presentation.nonce).toEqual(new Nonce('nonce-value'));
-    expect(presentation.ephemeralECDHPrivateJwk).toEqual(
-      new EphemeralECDHPrivateJwk('private-jwk')
+    expect(presentation.ephemeralECDHPublicJwk).toEqual(
+      new EphemeralECDHPublicJwk('public-jwk')
     );
     expect(presentation.responseMode).toEqual(ResponseModeOption.DirectPost);
     expect(presentation.getWalletResponseMethod).toEqual(
@@ -117,8 +118,8 @@ describe('Presentation.fromJSON', () => {
       request_object_retrieved_at: '2023-06-08T10:05:00Z',
       submitted_at: '2023-06-08T10:10:00Z',
       wallet_response: {
-        __type: 'IdToken',
-        id_token: 'id-token-value',
+        state: 'state',
+        response: 'response',
       },
       nonce: 'nonce-value',
       response_code: 'response-code-value',
@@ -140,8 +141,8 @@ describe('Presentation.fromJSON', () => {
     );
     expect(presentation.submittedAt).toEqual(new Date('2023-06-08T10:10:00Z'));
     expect(presentation.walletResponse).toMatchObject({
-      __type: 'IdToken',
-      idToken: 'id-token-value',
+      state: 'state',
+      response: 'response',
     });
     expect(presentation.nonce).toEqual(new Nonce('nonce-value'));
     expect(presentation.responseCode).toEqual(

--- a/lib/domain/index.ts
+++ b/lib/domain/index.ts
@@ -32,6 +32,7 @@ export * from './Nonce';
 export * from './PresentationType';
 export * from './WalletResponse';
 export * from './EphemeralECDHPrivateJwk';
+export * from './EphemeralECDHPublicJwk';
 export * from './StaticSigningPrivateJwk';
 export * from './ResponseCode';
 export * from './ResponseModeOption';

--- a/lib/ports/input/GetWalletResponse.ts
+++ b/lib/ports/input/GetWalletResponse.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ResponseCode, TransactionId } from '../../domain';
+import { DirectPostJwtJSON, ResponseCode, TransactionId } from '../../domain';
 import { QueryResponse } from './QueryResponse';
-import { WalletResponseTO } from './GetWalletResponse.types';
+// import { WalletResponseTO } from './GetWalletResponse.types';
 
 export { WalletResponseTO } from './GetWalletResponse.types';
 /**
@@ -40,7 +40,7 @@ export { WalletResponseTO } from './GetWalletResponse.types';
  */
 export interface GetWalletResponse {
   (transactionId: TransactionId, responseCode?: ResponseCode): Promise<
-    QueryResponse<WalletResponseTO>
+    QueryResponse<DirectPostJwtJSON>
   >;
 }
 //@Expose({ name: 'wallet_response' })

--- a/lib/ports/input/GetWalletResponse.ts
+++ b/lib/ports/input/GetWalletResponse.ts
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DirectPostJwtJSON, ResponseCode, TransactionId } from '../../domain';
+import {
+  AuthorizationResponseJSON,
+  ResponseCode,
+  TransactionId,
+} from '../../domain';
 import { QueryResponse } from './QueryResponse';
 // import { WalletResponseTO } from './GetWalletResponse.types';
 
@@ -40,7 +44,7 @@ export { WalletResponseTO } from './GetWalletResponse.types';
  */
 export interface GetWalletResponse {
   (transactionId: TransactionId, responseCode?: ResponseCode): Promise<
-    QueryResponse<DirectPostJwtJSON>
+    QueryResponse<AuthorizationResponseJSON>
   >;
 }
 //@Expose({ name: 'wallet_response' })

--- a/lib/ports/input/InitTransaction.types.ts
+++ b/lib/ports/input/InitTransaction.types.ts
@@ -19,6 +19,10 @@ import {
 } from '@vecrea/oid4vc-prex';
 import { z } from 'zod';
 import { FromJSON } from '../../common/json/FromJSON';
+import {
+  EphemeralECDHPublicJwk,
+  ephemeralECDHPublicJwkSchema,
+} from '../../domain';
 
 /**
  * Enumeration of presentation types for the transaction.
@@ -78,6 +82,7 @@ export const initTransactionSchema = z.object({
     .enum([EmbedModeTO.ByValue, EmbedModeTO.ByReference])
     .optional(),
   wallet_response_redirect_uri_template: z.string().optional(),
+  ephemeral_ecdh_public_jwk: ephemeralECDHPublicJwkSchema,
 });
 
 export type InitTransactionJSON = z.infer<typeof initTransactionSchema>;
@@ -91,9 +96,11 @@ export class InitTransactionTO {
   jarMode?: EmbedModeTO;
   presentationDefinitionMode?: EmbedModeTO;
   redirectUriTemplate?: string;
+  ephemeralECDHPublicJwkS: EphemeralECDHPublicJwk;
 
   constructor(
     type: PresentationTypeTO = PresentationTypeTO.IdAndVpTokenRequest,
+    ephemeralECDHPublicJwkS: EphemeralECDHPublicJwk,
     idTokenType?: IdTokenTypeTO,
     presentationDefinition?: PresentationDefinition,
     nonce?: string,
@@ -103,6 +110,7 @@ export class InitTransactionTO {
     redirectUriTemplate?: string
   ) {
     this.type = type;
+    this.ephemeralECDHPublicJwkS = ephemeralECDHPublicJwkS;
     this.idTokenType = idTokenType;
     this.presentationDefinition = presentationDefinition;
     this.nonce = nonce;
@@ -122,6 +130,7 @@ export class InitTransactionTO {
       jar_mode: this.jarMode,
       presentation_definition_mode: this.presentationDefinitionMode,
       wallet_response_redirect_uri_template: this.redirectUriTemplate,
+      ephemeral_ecdh_public_jwk: this.ephemeralECDHPublicJwkS.toJSON(),
     };
   }
 
@@ -130,6 +139,7 @@ export class InitTransactionTO {
   ) => {
     return new InitTransactionTO(
       json.type,
+      new EphemeralECDHPublicJwk(json.ephemeral_ecdh_public_jwk),
       json.id_token_type,
       json.presentation_definition &&
         PresentationDefinition.fromJSON(json.presentation_definition),

--- a/lib/ports/input/__tests__/InitTransaction.types.spec.ts
+++ b/lib/ports/input/__tests__/InitTransaction.types.spec.ts
@@ -53,7 +53,9 @@ describe('InitTransactionTO', () => {
     expect(instance.jarMode).toBe(EmbedModeTO.ByReference);
     expect(instance.presentationDefinitionMode).toBe(EmbedModeTO.ByValue);
     expect(instance.redirectUriTemplate).toBe('https://example.com/callback');
-    expect(instance.ephemeralECDHPublicJwkS).toBe('public-jwk');
+    expect(instance.ephemeralECDHPublicJwkS).toEqual(
+      new EphemeralECDHPublicJwk('public-jwk')
+    );
   });
 
   it('should convert class instance to plain object', () => {
@@ -157,6 +159,8 @@ describe('InitTransationSchema', () => {
       presentation_definition_mode: plainObject.presentation_definition_mode,
       wallet_response_redirect_uri_template:
         plainObject.wallet_response_redirect_uri_template,
+      ephemeral_ecdh_public_jwk:
+        '{"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM"}',
     });
 
     expect(schema.type).toBe(plainObject.type);

--- a/lib/ports/input/__tests__/InitTransaction.types.spec.ts
+++ b/lib/ports/input/__tests__/InitTransaction.types.spec.ts
@@ -10,6 +10,7 @@ import {
   initTransactionSchema,
   jwtSecuredAuthorizationRequestSchema,
 } from '../InitTransaction.types';
+import { EphemeralECDHPublicJwk } from '../../../domain';
 
 describe('InitTransactionTO', () => {
   it('should convert plain object to class instance', () => {
@@ -25,6 +26,7 @@ describe('InitTransactionTO', () => {
       jar_mode: EmbedModeTO.ByReference,
       presentation_definition_mode: EmbedModeTO.ByValue,
       wallet_response_redirect_uri_template: 'https://example.com/callback',
+      ephemeral_ecdh_public_jwk: 'public-jwk',
     };
 
     // const instance = plainToInstance(InitTransactionTO, plainObject);
@@ -51,6 +53,7 @@ describe('InitTransactionTO', () => {
     expect(instance.jarMode).toBe(EmbedModeTO.ByReference);
     expect(instance.presentationDefinitionMode).toBe(EmbedModeTO.ByValue);
     expect(instance.redirectUriTemplate).toBe('https://example.com/callback');
+    expect(instance.ephemeralECDHPublicJwkS).toBe('public-jwk');
   });
 
   it('should convert class instance to plain object', () => {
@@ -65,6 +68,7 @@ describe('InitTransactionTO', () => {
 
     const instance = new InitTransactionTO(
       PresentationTypeTO.IdTokenRequest,
+      new EphemeralECDHPublicJwk('public-jwk'),
       IdTokenTypeTO.AttesterSigned,
       dummyPresentationDefinition,
       'xyz789',

--- a/lib/services/input/GetWalletResponseService.ts
+++ b/lib/services/input/GetWalletResponseService.ts
@@ -17,7 +17,7 @@
 import { Duration } from '../../domain';
 import { QueryResponse, GetWalletResponse } from '../../ports/input';
 import { LoadPresentationById } from '../../ports/out/persistence';
-import { toWalletResponseTO } from './GetWalletResponseService.convert';
+// import { toWalletResponseTO } from './GetWalletResponseService.convert';
 
 export type GetWalletResponseCreateParams = {
   loadPresentationById: LoadPresentationById;
@@ -72,6 +72,7 @@ export const createGetWalletResponseServiceInvoker =
     }
 
     return new QueryResponse.Found(
-      toWalletResponseTO(presentation.walletResponse)
+      presentation.walletResponse.toJSON()
+      // toWalletResponseTO(presentation.walletResponse)
     );
   };

--- a/lib/services/input/InitTransactionService.ts
+++ b/lib/services/input/InitTransactionService.ts
@@ -39,10 +39,7 @@ import {
   toPresentationType,
   toResponseModeOption,
 } from './InitTransactionService.convert';
-import {
-  createEphemeralECDHPrivateJwk,
-  createJwtSecuredAuthorizationRequestTO,
-} from './InitTransactionService.create';
+import { createJwtSecuredAuthorizationRequestTO } from './InitTransactionService.create';
 
 type CreateParams = {
   generateTransactionId: GenerateTransactionId;
@@ -80,7 +77,6 @@ export const createInitTransactionServiceInvoker =
     signRequestObject,
     verifierConfig,
     now,
-    generateEphemeralECDHPrivateJwk,
     jarByReference,
     presentationDefinitionByReference,
     createQueryWalletResponseRedirectUri,
@@ -100,11 +96,11 @@ export const createInitTransactionServiceInvoker =
         initTransactionTO.responseMode,
         verifierConfig.responseModeOption
       );
-      const ephemeralECDHPrivateJwk = await createEphemeralECDHPrivateJwk(
-        responseMode,
-        verifierConfig.clientMetaData.jarmOption,
-        generateEphemeralECDHPrivateJwk
-      );
+      // const ephemeralECDHPrivateJwk = await createEphemeralECDHPrivateJwk(
+      //   responseMode,
+      //   verifierConfig.clientMetaData.jarmOption,
+      //   generateEphemeralECDHPrivateJwk
+      // );
       const getWalletResponseMethod = toGetWalletResponseMethod(
         initTransactionTO.redirectUriTemplate,
         createQueryWalletResponseRedirectUri
@@ -130,7 +126,7 @@ export const createInitTransactionServiceInvoker =
         type,
         requestId,
         nonce,
-        ephemeralECDHPrivateJwk,
+        initTransactionTO.ephemeralECDHPublicJwkS,
         responseMode,
         presentationDefinitionMode,
         getWalletResponseMethod

--- a/lib/services/input/PostWalletResponseService.ts
+++ b/lib/services/input/PostWalletResponseService.ts
@@ -30,8 +30,8 @@ import { runAsyncCatching, Result } from '@vecrea/oid4vc-core/utils';
 import {
   getRequestId,
   getReponseModeOption,
-  toAuthorizationResponseData,
-  toWalletResponse,
+  // toAuthorizationResponseData,
+  // toWalletResponse,
 } from './PostWalletResponseService.convert';
 import {
   createResponseCode,
@@ -52,9 +52,9 @@ export const createPostWalletResponseServiceInvoker =
   ({
     loadPresentationByRequestId,
     storePresentation,
-    verifyJarmJwt,
+    // verifyJarmJwt,
     now,
-    verifierConfig,
+    // verifierConfig,
     generateResponseCode,
     createQueryWalletResponseRedirectUri,
   }: CreateParams): PostWalletResponse =>
@@ -80,22 +80,26 @@ export const createPostWalletResponseServiceInvoker =
         throw new Error('Unexpected response mode');
       }
 
-      const authorizationResponseData = await toAuthorizationResponseData(
-        authorizationResponse,
-        verifyJarmJwt,
-        verifierConfig.clientMetaData.jarmOption,
-        presentation.ephemeralECDHPrivateJwk
-      );
-      const walletResponse = await toWalletResponse(
-        authorizationResponseData,
-        presentation.type
-      );
+      // const authorizationResponseData = await toAuthorizationResponseData(
+      //   authorizationResponse,
+      //   verifyJarmJwt,
+      //   verifierConfig.clientMetaData.jarmOption,
+      //   presentation.ephemeralECDHPublicJwk
+      // );
+      // const walletResponse = await toWalletResponse(
+      //   authorizationResponseData,
+      //   presentation.type
+      // );
       const responseCode = await createResponseCode(
         presentation.getWalletResponseMethod,
         generateResponseCode
       );
       const submitted = presentation
-        .submit(now(), walletResponse, responseCode)
+        .submit(
+          now(),
+          authorizationResponse as AuthorizationResponse.DirectPostJwt,
+          responseCode
+        )
         .getOrThrow();
       await storePresentation(submitted);
 

--- a/lib/services/input/__tests__/GetWalletResponseService.spec.ts
+++ b/lib/services/input/__tests__/GetWalletResponseService.spec.ts
@@ -9,7 +9,7 @@ import {
 import {
   Id,
   PresentationDefinition,
-  PresentationSubmission,
+  // PresentationSubmission,
 } from '@vecrea/oid4vc-prex';
 import {
   EmbedModeTO,
@@ -21,7 +21,7 @@ import {
 import { CompactEncrypt, importJWK } from 'jose';
 import { MockConfiguration } from '../../../di/MockConfiguration';
 import { PortsInputImpl, PortsOutImpl } from '../../../di';
-import { WalletResponseTO } from '../../../ports/input';
+// import { WalletResponseTO } from '../../../ports/input';
 import {
   GetWalletResponseCreateParams,
   createGetWalletResponseServiceInvoker,
@@ -89,7 +89,7 @@ describe('createGetWalletResponseServiceInvoker', async () => {
     ).setProtectedHeader({ alg: 'ECDH-ES+A256KW', enc: 'A256GCM' });
 
     const verifierPrivateJwk = JSON.parse(
-      presentation.ephemeralECDHPrivateJwk!.value
+      presentation.ephemeralECDHPublicJwk!.value
     );
     delete verifierPrivateJwk.d;
     const publicKey = await importJWK(verifierPrivateJwk);
@@ -129,11 +129,11 @@ describe('createGetWalletResponseServiceInvoker', async () => {
         ? getWalletResponseResponse.value
         : undefined
     )!;
-    expect(walletResponseTO).toBeInstanceOf(WalletResponseTO);
-    expect(walletResponseTO.vpToken).toBe('vpToken');
-    expect(walletResponseTO.presentationSubmission).toBeInstanceOf(
-      PresentationSubmission
+    expect(walletResponseTO).toBeInstanceOf(
+      AuthorizationResponse.DirectPostJwt
     );
+    expect(walletResponseTO.state).toBe('state');
+    expect(walletResponseTO.response).toBe('response');
     //console.log(getWalletResponseResponse);
   });
 

--- a/lib/services/input/__tests__/PostWalletResponseService.spec.ts
+++ b/lib/services/input/__tests__/PostWalletResponseService.spec.ts
@@ -7,6 +7,7 @@ import {
   ResponseCode,
   AuthorizationResponse,
   ResponseModeOption,
+  EphemeralECDHPublicJwk,
 } from '../../../domain';
 import { Id, PresentationDefinition } from '@vecrea/oid4vc-prex';
 import {
@@ -43,6 +44,9 @@ describe('createGetRequestObjectServiceInvoker', async () => {
 
     const initTransactionTO: InitTransactionTO = {
       type: PresentationTypeTO.VpTokenRequest,
+      ephemeralECDHPublicJwkS: new EphemeralECDHPublicJwk(
+        '{"kty":"EC","crv":"P-256","x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4","y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM","d":"870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE"}'
+      ),
       idTokenType: IdTokenTypeTO.SubjectSigned,
       nonce: 'nonce',
       responseMode: ResponseModeTO.DirectPostJwt,

--- a/lib/services/input/__tests__/PostWalletResponseService.spec.ts
+++ b/lib/services/input/__tests__/PostWalletResponseService.spec.ts
@@ -94,7 +94,7 @@ describe('createGetRequestObjectServiceInvoker', async () => {
     ).setProtectedHeader({ alg: 'ECDH-ES+A256KW', enc: 'A256GCM' });
 
     const verifierPrivateJwk = JSON.parse(
-      presentation.ephemeralECDHPrivateJwk!.value
+      presentation.ephemeralECDHPublicJwk!.value
     );
     delete verifierPrivateJwk.d;
     const publicKey = await importJWK(verifierPrivateJwk);


### PR DESCRIPTION
## Changed

- Receive ECDH-ES public key for wallet response encryption from Frontend instead of generating it at Endpoint